### PR TITLE
集成angularjs的编辑器初始化内容

### DIFF
--- a/test/angular/test-angular.html
+++ b/test/angular/test-angular.html
@@ -18,12 +18,7 @@
     
     <div ng-app="editorContainer" ng-controller="editorCtrl">
         <p>wangEditor 集成到 angular 的示例</p>
-        <div id="editor-trigger" ng-model="editorContent" contenteditable="true">
-        </div>
-        <hr>
-        <p><b>以下是编辑器的内容：</b></p>
-        <p ng-bind="editorContent"></p>
-
+        <div ng-model="text" contenteditable="true"></div>
     </div>
 
     <script type="text/javascript" src="../../dist/js/lib/jquery-1.10.2.min.js"></script>
@@ -36,17 +31,34 @@
         app.directive('contenteditable', function() {
             return {
                 restrict: 'A' ,
-                require: 'ngModel',
-                link: function(scope, element, attrs, ctrl) {
-                    // 创建编辑器
-                    var editor = new wangEditor('editor-trigger');
-                    editor.onchange = function () {
-                        // 从 onchange 函数中更新数据
-                        scope.$apply(function () {
-                            var html = editor.$txt.html();
-                            ctrl.$setViewValue(html);
-                        });
+                require: '?ngModel',
+                link: function(scope, element, attrs, ngModel) {
+                    // 初始化 编辑器内容
+                    if (!ngModel) {
+                        return;
+                    } // do nothing if no ng-model
+                    // Specify how UI should be updated
+                    ngModel.$render = function() {
+                        element.html(ngModel.$viewValue || '');
                     };
+                    // Listen for change events to enable binding
+                    element.on('blur keyup change', function() {
+                        scope.$apply(readViewText);
+                    });
+                    // No need to initialize, AngularJS will initialize the text based on ng-model attribute
+                    // Write data to the model
+                    function readViewText() {
+                        var html = element.html();
+                        // When we clear the content editable the browser leaves a <br> behind
+                        // If strip-br attribute is provided then we strip this out
+                        if (attrs.stripBr && html === '<br>') {
+                            html = '';
+                        }
+                        ngModel.$setViewValue(html);
+                    }
+        
+                    // 创建编辑器
+                    var editor = new wangEditor(element);
                     editor.create();
                 }
             };


### PR DESCRIPTION
原先的集成在contenteditable下的ngModel无法实现双向绑定的内容初始化