### PR TITLE
在firefox(火狐)中，当把编辑器放入iframe中使用时，导致错误无法使用

### DIFF
--- a/src/js/wangEditor.js
+++ b/src/js/wangEditor.js
@@ -325,7 +325,7 @@ _e(function (E, $) {
             _parentElem = range.commonAncestorContainer;
         } else {
             selection = document.getSelection();
-            if (selection.getRangeAt && selection.rangeCount) {
+            if (selection && selection.getRangeAt && selection.rangeCount) {
                 range = document.getSelection().getRangeAt(0);
                 _parentElem = range.commonAncestorContainer;
             }

--- a/src/js/wangEditor.js
+++ b/src/js/wangEditor.js
@@ -2730,7 +2730,7 @@ _e(function (E, $) {
         var $wrap = $('<div>');
 
         // 需要浏览器支持 max-height，否则不管
-        if (window.getComputedStyle && 'max-height'in window.getComputedStyle($txt.get(0))) {
+        if (window.getComputedStyle && window.getComputedStyle($txt.get(0)) && 'max-height'in window.getComputedStyle($txt.get(0))) {
             // 获取 max-height 并判断是否有值
             var maxHeight = parseInt(editor.$valueContainer.css('max-height'));
             if (isNaN(maxHeight)) {

--- a/src/js/wangEditor.js
+++ b/src/js/wangEditor.js
@@ -955,7 +955,11 @@ _e(function (E, $) {
         var _plugins = E._plugins;
         if (_plugins && _plugins.length) {
             $.each(_plugins, function (k, val) {
-                val.call(editor);
+                try {
+                    val.call(editor);
+                }catch(e){
+
+                }
             });
         }
     };


### PR DESCRIPTION
在firefox(火狐)中，当把编辑器放入iframe中使用时，导致错误无法使用，主要有window.getComputedStyle 及 document.getSelection()方法均返回null