### PR TITLE
Update wangEditor.js

### DIFF
--- a/src/js/wangEditor.js
+++ b/src/js/wangEditor.js
@@ -3547,8 +3547,8 @@ _e(function (E, $) {
 
     E.fn.initDefaultConfig = function () {
         var editor = this;
-        editor.config = $.extend({}, E.config);
-        editor.UI = $.extend({}, E.UI);
+        editor.config = $.extend(true, {}, E.config);
+        editor.UI = $.extend(true, {}, E.UI);
     };
 
 });


### PR DESCRIPTION
使用react在页面存在多个编辑器，并且只有一个实例的时候，上传图片会总是会传递到最后一个编辑器里，根据issue中的修改解决了问题