### PR TITLE
图片上传服务端返回到错误码如果不是errno的处理

### DIFF
--- a/src/js/editor/upload/upload-img.js
+++ b/src/js/editor/upload/upload-img.js
@@ -192,7 +192,7 @@ UploadImg.prototype = {
                             return
                         }
                     }
-                    if (result.errno != '0') {
+                    if (retult.errno && result.errno != '0') {
                         // hook - fail
                         if (hooks.fail && typeof hooks.fail === 'function') {
                             hooks.fail(xhr, editor, result)


### PR DESCRIPTION
图片上传服务端返回到错误码如果不是errno，比如是errcode，则执行时将不会执行customInsert方法，导致图片上传成功但是无法插入到编辑器中~