### PR TITLE
修复 在输入法输入未完成时触发change事件

### DIFF
--- a/src/js/editor/index.js
+++ b/src/js/editor/index.js
@@ -128,9 +128,22 @@ Editor.prototype = {
         this.toolbarElemId = toolbarElemId
         this.textElemId = textElemId
 
+        // 记录输入法是否已输入结束
+        let compositionEnd = true
+
+        // 输入法开始输入
+        $textContainerElem.on('compositionstart', () => {
+            compositionEnd = false
+        })
+
+        // 输入法结束输入
+        $textContainerElem.on('compositionend', () => {
+            compositionEnd = true
+        })
+
         // 绑定 onchange
         $textContainerElem.on('click keyup', () => {
-            this.change &&  this.change()
+            compositionEnd && this.change &&  this.change()
         })
         $toolbarElem.on('click', function () {
             this.change &&  this.change()

--- a/src/less/menus.less
+++ b/src/less/menus.less
@@ -1,6 +1,7 @@
 .w-e-toolbar {
     display: flex;
     padding: 0 5px;
+    flex-wrap: wrap;
 
     /* 单个菜单 */
     .w-e-menu {


### PR DESCRIPTION
修复 #1223 
输入法在输入状态时，并未输入完成，触发了`change`事件。
经测试原生`input`并无此现象，查询发现change事件触发应该在**IME（input method editor）的启动和关闭后触发**，对应的事件为`compositionstart`和`compositionend`
![image](https://user-images.githubusercontent.com/16128049/34199952-5224dc06-e5aa-11e7-93a1-22d9ea8cd3e8.png)