### PR TITLE
修复点击编辑器内的不可编辑区域时丢失选区的Bug

### DIFF
--- a/src/js/selection/index.js
+++ b/src/js/selection/index.js
@@ -40,6 +40,12 @@ API.prototype = {
         if (!$containerElem) {
             return
         }
+
+        // 判断选区内容是否在不可编辑区域之内
+        if ($containerElem.attr('contenteditable') === 'false' || $containerElem.parentUntil('[contenteditable=false]')) {
+            return
+        }
+
         const editor = this.editor
         const $textElem = editor.$textElem
         if ($textElem.isContain($containerElem)) {


### PR DESCRIPTION
当需要自定义插入的组件时，比如：

<img width="562" alt="zhihu" src="https://user-images.githubusercontent.com/2156642/35101743-e123cf76-fc60-11e7-90b4-4a09046b426d.png">

常常会需要将组件的容器的 `contenteditable` 设置为 `false`，以防用户改动组件内容，但如果鼠标点击该组件，选区将进入到该不可编辑的容器之中，此时会导致无法使用 `insertHTML` 命令插入新的内容。